### PR TITLE
Create ntproperty wrapper for working with no NT library installed

### DIFF
--- a/server/cameras.py
+++ b/server/cameras.py
@@ -71,7 +71,7 @@ class Camera:
         '''Set the camera exposure. 0 means auto exposure'''
 
         logging.info(f"Setting camera exposure to '{value}'")
-        if value == 0:
+        if value <= 0:
             self.camera.setExposureAuto()
             # Logitech does not like having exposure_auto_priority on when the light is poor
             #  slows down the frame rate

--- a/server/fastfinder2022.py
+++ b/server/fastfinder2022.py
@@ -77,6 +77,8 @@ class ContourInfo:
 class FastFinder2022(GenericFinder):
     '''Find hub ring for 2022 game using a fast circle fit'''
 
+    # NOTE: FastFinder is a replacement for Hubfinder, so re-use the name.
+
     # inches
     CAMERA_HEIGHT = 33
     CAMERA_ANGLE = math.radians(31)
@@ -92,23 +94,23 @@ class FastFinder2022(GenericFinder):
     # self.high_limit_hsv = np.array((160, 255, 255), dtype=np.uint8)
 
     # Color threshold values, in HSV space
-    hue_low_limit = ntproperty('/SmartDashboard/vision/fastfinder/hue_low_limit', 50,
+    hue_low_limit = ntproperty('/SmartDashboard/vision/hubfinder/hue_low_limit', 50,
                                doc='Hue low limit for thresholding')
-    hue_high_limit = ntproperty('/SmartDashboard/vision/fastfinder/hue_high_limit', 90,
+    hue_high_limit = ntproperty('/SmartDashboard/vision/hubfinder/hue_high_limit', 90,
                                 doc='Hue high limit for thresholding')
 
-    saturation_low_limit = ntproperty('/SmartDashboard/vision/fastfinder/saturation_low_limit', 110,
+    saturation_low_limit = ntproperty('/SmartDashboard/vision/hubfinder/saturation_low_limit', 110,
                                       doc='Saturation low limit for thresholding')
-    saturation_high_limit = ntproperty('/SmartDashboard/vision/fastfinder/saturation_high_limit', 255,
+    saturation_high_limit = ntproperty('/SmartDashboard/vision/hubfinder/saturation_high_limit', 255,
                                        doc='Saturation high limit for thresholding')
 
-    value_low_limit = ntproperty('/SmartDashboard/vision/fastfinder/value_low_limit', 110,
+    value_low_limit = ntproperty('/SmartDashboard/vision/hubfinder/value_low_limit', 110,
                                  doc='Value low limit for thresholding')
-    value_high_limit = ntproperty('/SmartDashboard/vision/fastfinder/value_high_limit', 255,
+    value_high_limit = ntproperty('/SmartDashboard/vision/hubfinder/value_high_limit', 255,
                                   doc='Value high limit for thresholding')
 
     def __init__(self, calib_matrix=None, dist_matrix=None):
-        super().__init__('fastfinder', camera='shooter', finder_id=1.0, exposure=1)
+        super().__init__('hubfinder', camera='shooter', finder_id=1.0, exposure=1)
 
         # Color threshold values, in HSV space
         # Somewhat faster to keep the arrays around and update the values inside

--- a/server/ntprop_wrapper.py
+++ b/server/ntprop_wrapper.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python3
+
+# Create a wrapper around the official WPILib ntproperty function
+# This is needed so that the Finder classes can fake using ntproperties when NetworkTables is not installed.
+#  Much easier development/debugging that way.
+
+__all__ = ["ntproperty", ]
+
+try:
+    raise Exception
+    from networktables.util import ntproperty
+except Exception:
+    print('No WPILib ntproperty')
+
+    class _NtProperty:
+        def __init__(self, defaultValue) -> None:
+            self._value = None
+            self.set(None, defaultValue)
+            return
+
+        def get(self, _):
+            return self._value
+
+        def set(self, _, value):
+            # NT does not have int storage, so convert to float to get the same behavior
+            if isinstance(value, int):
+                self._value = float(value)
+            else:
+                self._value = value
+            return
+
+    def ntproperty(key: str, defaultValue, *, doc: str = None) -> property:
+        """
+        Replacement for WPILib ntproperty to be used when NT is not loaded on the machine
+
+        :param key: A full NetworkTables key (eg ``/SmartDashboard/foo``) - ignored
+        :param defaultValue: Default value to use if not in the table
+        :type  defaultValue: any
+        :param writeDefault: If True, put the default value to the table,
+                             overwriting existing values
+        :param doc: If given, will be the docstring of the property.
+        :param persistent: If True, persist set values across restarts.
+                           *writeDefault* is ignored if this is True.
+        """
+
+        ntprop = _NtProperty(defaultValue)
+        return property(fget=ntprop.get, fset=ntprop.set, doc=doc)
+
+
+if __name__ == '__main__':
+    # test cases
+
+    class TestClass:
+        test_val = ntproperty('/SmartDashboard/vision/test_value', 30, doc='Test value')
+
+    test_inst = TestClass()
+    print('test_val initial value', test_inst.test_val)
+    for i in range(3):
+        test_inst.test_val = i
+        print('set test_val', i, test_inst.test_val)

--- a/server/ntprop_wrapper.py
+++ b/server/ntprop_wrapper.py
@@ -7,7 +7,6 @@
 __all__ = ["ntproperty", ]
 
 try:
-    raise Exception
     from networktables.util import ntproperty
 except Exception:
     print('No WPILib ntproperty')

--- a/server/visionserver.py
+++ b/server/visionserver.py
@@ -5,7 +5,6 @@
 # import sys
 from time import time, sleep
 import cv2
-import numpy
 import logging
 
 import cscore
@@ -37,10 +36,6 @@ class VisionServer:
     # fix the TCP port for the main video, so it does not change with multiple cameras
     output_port = ntproperty('/SmartDashboard/vision/output_port', 1190,
                              doc='TCP port for main image output')
-
-    # Operation modes. Force the value on startup.
-    tuning = ntproperty('/SmartDashboard/vision/tuning', False, writeDefault=True,
-                        doc='Tuning mode. Reads processing parameters each time.')
 
     # Logitech c930 are wide-screen cameras, so 424x240 is the correct proportion
     image_width = ntproperty('/SmartDashboard/vision/width', 424, writeDefault=False, doc='Image width')
@@ -107,18 +102,6 @@ class VisionServer:
                                         capture_period=0.5, image_format='png')
 
         return
-
-    # --------------------------------------------------------------------------------
-    # Methods generally customized each year
-
-    """Methods you should/must include"""
-
-    def update_parameters(self):
-        '''Update processing parameters from NetworkTables values.
-        Only do this on startup or if "tuning" is on, for efficiency'''
-
-        # Make sure to add any additional created properties which should be changeable
-        raise NotImplementedError
 
     # --------------------------------------------------------------------------------
     # Methods which hopefully don't need to be updated
@@ -262,10 +245,6 @@ class VisionServer:
             if self.image_writer_state:
                 cv2.circle(self.output_frame, (20, 20), dotrad, (0, 0, 255), thickness=2*dotrad, lineType=8, shift=0)
 
-            # If tuning mode is on, add text to the upper left corner saying "Tuning On"
-            if self.tuning:
-                cv2.putText(self.output_frame, "TUNING ON", (60, 30), cv2.FONT_HERSHEY_SIMPLEX, fontscale, (255, 0, 0), thickness=fontthick)
-
             # If test mode (ie running the NT server), give a warning
             if self.test_mode:
                 cv2.putText(self.output_frame, "TEST MODE", (5, self.output_frame.shape[0]-5), cv2.FONT_HERSHEY_SIMPLEX,
@@ -297,9 +276,6 @@ class VisionServer:
 
                 # if self.camera_frame is None:
                 #     self.preallocate_arrays()
-
-                if self.tuning:
-                    self.update_parameters()
 
                 # Tell the CvReader to grab a frame from the camera and put it
                 # in the source image.  Frametime==0 on error

--- a/server/visionserver.py
+++ b/server/visionserver.py
@@ -443,7 +443,7 @@ def main(server_type):
 
     import argparse
     parser = argparse.ArgumentParser(description='LigerBots Vision Server')
-    parser.add_argument('--calib_dir', required=True, help='Directory for calibration files')
+    parser.add_argument('--calib-dir', required=True, help='Directory for calibration files')
     parser.add_argument('--test', action='store_true', help='Run in local test mode')
     parser.add_argument('--delay', type=int, default=0, help='Max delay trying to connect to NT server (seconds)')
     parser.add_argument('--verbose', '-v', action='store_true', help='Verbose. Turn up debug messages')

--- a/server/visionserver2022.py
+++ b/server/visionserver2022.py
@@ -2,8 +2,6 @@
 
 '''Vision server for 2022 Rapid React'''
 
-from networktables.util import ntproperty
-
 from visionserver import VisionServer, main
 import cameras
 from genericfinder import GenericFinder
@@ -28,8 +26,6 @@ class VisionServer2022(VisionServer):
         cam = self.cameras['shooter']
         self.hub_finder = HubFinder2022(cam.calibration_matrix, cam.distortion_matrix)
         self.add_target_finder(self.hub_finder)
-
-        self.update_parameters()
 
         # DEBUG: capture an image every 100ms - this is too fast for normal testing
         self.image_writer.capture_period = 0.120

--- a/server/visionserver2022.py
+++ b/server/visionserver2022.py
@@ -12,27 +12,6 @@ from fastfinder2022 import FastFinder2022 as HubFinder2022
 
 
 class VisionServer2022(VisionServer):
-
-    # Retro-reflective target finding parameters
-
-    # Color threshold values, in HSV space
-    hub_hue_low_limit = ntproperty('/SmartDashboard/vision/hub/hue_low_limit', 50,
-                                   doc='Hue low limit for thresholding (rrtarget mode)')
-    hub_hue_high_limit = ntproperty('/SmartDashboard/vision/hub/hue_high_limit', 90,
-                                    doc='Hue high limit for thresholding (rrtarget mode)')
-
-    hub_saturation_low_limit = ntproperty('/SmartDashboard/vision/hub/saturation_low_limit', 110,
-                                          doc='Saturation low limit for thresholding (rrtarget mode)')
-    hub_saturation_high_limit = ntproperty('/SmartDashboard/vision/hub/saturation_high_limit', 255,
-                                           doc='Saturation high limit for thresholding (rrtarget mode)')
-
-    hub_value_low_limit = ntproperty('/SmartDashboard/vision/hub/value_low_limit', 110,
-                                     doc='Value low limit for thresholding (rrtarget mode)')
-    hub_value_high_limit = ntproperty('/SmartDashboard/vision/hub/value_high_limit', 255,
-                                      doc='Value high limit for thresholding (rrtarget mode)')
-
-    # rrtarget_exposure = ntproperty('/SmartDashboard/vision/rrtarget/exposure', 0, doc='Camera exposure for rrtarget (0=auto)')
-
     def __init__(self, calib_dir, test_mode=False):
         super().__init__(initial_mode='shooter', test_mode=test_mode)
 
@@ -59,20 +38,6 @@ class VisionServer2022(VisionServer):
         self.switch_mode('intake')
         return
 
-    def update_parameters(self):
-        '''Update processing parameters from NetworkTables values.
-        Only do this on startup or if "tuning" is on, for efficiency'''
-
-        # Make sure to add any additional created properties which should be changeable
-        self.hub_finder.low_limit_hsv[0] = int(self.hub_hue_low_limit)
-        self.hub_finder.low_limit_hsv[1] = int(self.hub_saturation_low_limit)
-        self.hub_finder.low_limit_hsv[2] = int(self.hub_value_low_limit)
-
-        self.hub_finder.high_limit_hsv[0] = int(self.hub_hue_high_limit)
-        self.hub_finder.high_limit_hsv[1] = int(self.hub_saturation_high_limit)
-        self.hub_finder.high_limit_hsv[2] = int(self.hub_value_high_limit)
-        return
-
     def add_cameras(self, calib_dir):
         '''Add the cameras'''
 
@@ -89,9 +54,7 @@ class VisionServer2022(VisionServer):
         return
 
     def mode_after_error(self):
-        if self.active_mode == 'intake':
-            return 'shooter'
-        return 'intake'
+        return 'shooter' if self.active_mode == 'intake' else 'intake'
 
     def switch_mode(self, new_mode):
         '''Switch processing mode. new_mode is the string name'''


### PR DESCRIPTION
To simplify tuning, it will be much easier to have the values like HSV thresholds stored in NetworkTables and used each frame. However, the Finders don't use NT directly so that they can be tested  on any machine.

Create a wrapper for the ntproperty class. If pynetworktables is available, just use it. Otherwise, fake up a little value store.